### PR TITLE
driver/hp-wmi.c: fix driver data for board 8BA9

### DIFF
--- a/driver/hp-wmi.c
+++ b/driver/hp-wmi.c
@@ -307,7 +307,7 @@ static const struct dmi_system_id victus_s_thermal_profile_boards[] __initconst 
 	},
 	{
 		.matches    = {DMI_MATCH(DMI_BOARD_NAME, "8BA9")},
-		.driver_data = (void *)&omen_v1_legacy_thermal_params,
+		.driver_data = (void *)&omen_v1_thermal_params,
 	},
 	{
 		/*


### PR DESCRIPTION
HP OMEN 16-wd0xxx's thermal profile offset is 0x59- not 0x95, as followed by most previous OMEN boards.

Therefore, it has to be mapped to the ```omen_v1_thermal_params``` driver data for the profile reporting and switching to properly work.

This has been tested on the same baseboard product.