### PR TITLE
change zypper dependencies error

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -283,8 +283,18 @@ install_dependencies() {
         apt)
             $INSTALL_CMD python3 python3-gi python3-gi-cairo gir1.2-gtk-4.0 gir1.2-adw-1 python3-pydbus python3-cairo python3-pystray python3-pil python3-evdev acpica-tools cmake gcc g++ make libpci-dev
             ;;
-        dnf|zypper)
-            $INSTALL_CMD python3 python3-gobject gtk4 libadwaita python3-pydbus python3-cairo python3-pystray python3-pillow python3-evdev acpica-tools cmake gcc gcc-c++ make pciutils-devel
+        dnf)
+            $INSTALL_CMD python3 python3-gobject gtk4 libadwaita python3-pydbus python3-cairo python3-pystray python3-pillow python3-evdev acpica cmake gcc gcc-c++ make pciutils-devel
+            ;;
+        zypper)
+            # openSUSE requires python313-Pillow and acpica
+            $INSTALL_CMD python3 python3-gobject gtk4 libadwaita python3-pydbus python3-cairo python313-pillow python3-evdev acpica cmake gcc gcc-c++ make pciutils-devel || true
+            
+            # Fallback to pip for pystray since it isn't in openSUSE repos
+            if ! python3 -c "import pystray" &>/dev/null; then
+                info "Installing pystray via pip..."
+                pip install --user --break-system-packages pystray 2>/dev/null || pip install --user pystray 2>/dev/null || true
+            fi
             ;;
     esac
 


### PR DESCRIPTION
Trying to fix these issue when executing setup.sh, it does installs but issue arise in the app (fan, rgb, power mode not works see [here](https://github.com/yunusemreyl/OmenCtl/issues/171)) , not sure cause by this or not
```
Package 'acpica-tools' not found.
'gcc-c++' is already installed.
No update candidate for 'gcc-c++-16-1.1.x86_64'. The highest available version is already installed.
'cmake' is already installed.
No update candidate for 'cmake-4.4.2-1.1.x86_64'. The highest available version is already installed.
'make' is already installed.
No update candidate for 'make-4.4.1-3.7.x86_64'. The highest available version is already installed.
'gcc' is already installed.
No update candidate for 'gcc-16-1.1.x86_64'. The highest available version is already installed.
'python3' not found in package names. Trying capabilities.
'python313' providing 'python3' is already installed.
'python3-cairo' not found in package names. Trying capabilities.
'python313-pycairo' providing 'python3-cairo' is already installed.
'python3-gobject' not found in package names. Trying capabilities.
'python313-gobject' providing 'python3-gobject' is already installed.
'python3-evdev' not found in package names. Trying capabilities.
'python313-evdev' providing 'python3-evdev' is already installed.
'gtk4' not found in package names. Trying capabilities.
'libgtk-4-1' providing 'gtk4' is already installed.
'python3-pydbus' not found in package names. Trying capabilities.
'python313-pydbus' providing 'python3-pydbus' is already installed.
'libadwaita' not found in package names. Trying capabilities.
'libadwaita-1-0' providing 'libadwaita' is already installed.
'python3-pillow' not found in package names. Trying capabilities.
No provider of 'python3-pillow' found.
'python3-pystray' not found in package names. Trying capabilities.
No provider of 'python3-pystray' found.
```