### PR TITLE
fix(tray,gui): prevent duplicate tray instances and integrate gui with tray

### DIFF
--- a/src/omen-gui/src/main.rs
+++ b/src/omen-gui/src/main.rs
@@ -24,6 +24,7 @@ fn main() {
     app.connect_startup(|_| {
         adw::init().expect("Failed to initialize libadwaita");
         i18n::init();
+        ensure_tray_running();
         
         let display = gtk::gdk::Display::default().unwrap();
         let icon_theme = gtk::IconTheme::for_display(&display);
@@ -88,11 +89,31 @@ fn apply_appearance_mode() {
     }
 }
 
+fn ensure_tray_running() {
+    std::thread::spawn(|| {
+        let spawned = std::process::Command::new("omen-tray")
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn();
+
+        if spawned.is_err() {
+            let _ = std::process::Command::new("/usr/bin/omen-tray")
+                .stdin(std::process::Stdio::null())
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::null())
+                .spawn();
+        }
+    });
+}
+
 fn build_ui(app: &adw::Application) {
+    ensure_tray_running();
     apply_startup_profile();
     apply_appearance_mode();
 
-    if let Some(window) = app.active_window() {
+    if let Some(window) = app.active_window().or_else(|| app.windows().first().cloned()) {
+        window.set_visible(true);
         window.present();
         return;
     }

--- a/src/omen-tray/Cargo.lock
+++ b/src/omen-tray/Cargo.lock
@@ -772,6 +772,7 @@ dependencies = [
  "env_logger",
  "glib",
  "ksni",
+ "libc",
  "log",
  "serde",
  "serde_json",

--- a/src/omen-tray/Cargo.toml
+++ b/src/omen-tray/Cargo.toml
@@ -12,6 +12,7 @@ env_logger = "0.10"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 glib = "0.18"
+libc = "0.2"
 
 [profile.release]
 opt-level = "z"

--- a/src/omen-tray/src/main.rs
+++ b/src/omen-tray/src/main.rs
@@ -1,11 +1,42 @@
 use ksni::menu::{CheckmarkItem, StandardItem, SubMenu};
 use ksni::MenuItem;
-use log::{error, info};
+use log::{error, info, warn};
+use std::fs::OpenOptions;
+use std::os::unix::io::AsRawFd;
 use std::process::Command;
 use std::sync::OnceLock;
 use zbus::{Connection, Result as ZbusResult};
 
 static RUNTIME: OnceLock<tokio::runtime::Handle> = OnceLock::new();
+
+fn acquire_single_instance_lock() -> Option<std::fs::File> {
+    let runtime_dir = std::env::var("XDG_RUNTIME_DIR")
+        .unwrap_or_else(|_| format!("/tmp/user-{}", unsafe { libc::getuid() }));
+    let _ = std::fs::create_dir_all(&runtime_dir);
+    let lock_path = format!("{}/omen-tray.lock", runtime_dir);
+
+    let file = match OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(&lock_path)
+    {
+        Ok(f) => f,
+        Err(e) => {
+            warn!("Kilit dosyası açılamadı ({}): {}, tekillik kontrolü atlanıyor.", lock_path, e);
+            return None;
+        }
+    };
+
+    let fd = file.as_raw_fd();
+    let res = unsafe { libc::flock(fd, libc::LOCK_EX | libc::LOCK_NB) };
+    if res != 0 {
+        return None;
+    }
+
+    Some(file)
+}
 
 fn spawn_task<F>(f: F)
 where
@@ -179,6 +210,11 @@ impl ksni::Tray for Tray {
                 label: "❌ Çıkış".into(),
                 icon_name: "application-exit".into(),
                 activate: Box::new(|_| {
+                    let _ = Command::new("pkill")
+                        .arg("-TERM")
+                        .arg("-x")
+                        .arg("omen-gui")
+                        .output();
                     std::process::exit(0);
                 }),
                 ..Default::default()
@@ -264,6 +300,14 @@ async fn set_fan_mode(mode: &str) {
 async fn main() {
     env_logger::init();
     info!("omen-tray başlatılıyor...");
+
+    let _lock = match acquire_single_instance_lock() {
+        Some(lock) => lock,
+        None => {
+            info!("omen-tray zaten çalışıyor. İkinci kopya sonlandırılıyor.");
+            return;
+        }
+    };
 
     RUNTIME
         .set(tokio::runtime::Handle::current())


### PR DESCRIPTION
## Description

This PR resolves two related UX and lifecycle issues with `omen-tray` and `omen-gui`:

1. **Duplicate Tray Icons:**
   - `omen-tray` previously lacked any single-instance mechanism. If triggered multiple times (e.g. by desktop autostart, systemd service, or manual launch), multiple tray icons would populate the system tray.
   - Added a robust single-instance file lock using `flock` on `$XDG_RUNTIME_DIR/omen-tray.lock`. Subsequent instances detect the existing process and exit immediately with code 0.

2. **GUI & Tray Integration:**
   - When `omen-gui` is launched (e.g. via KRunner, application menu, or terminal), it now ensures `omen-tray` is running in the background. Because of the single-instance guard, this is a no-op if `omen-tray` is already active.
   - Fixed hidden window restoration: previously, clicking close hid the window (`set_visible(false)`), which caused `app.active_window()` to return `None` on subsequent launches, failing to restore the existing window. Now it checks `app.windows().first()` to properly make the hidden window visible and present it.

3. **Clean Exit:**
   - Selecting 'Çıkış' (Exit) from the tray context menu now gracefully terminates any running/minimized `omen-gui` process (`pkill -TERM -x omen-gui`) to prevent lingering background instances.