### PR TITLE
feat(installer): add openSUSE (zypper) dependency support

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ sudo ./setup.sh uninstall  # Completely removes OMENSpace, daemon, and the DKMS 
 - **Ubuntu / Debian / Pop!_OS:** Uses `apt-get` to install dependencies and kernel development packages.
 - **Arch Linux / Manjaro:** Uses `pacman` to install build dependencies, or install directly using the provided `PKGBUILD` (`makepkg -si`).
 - **NixOS:** Provided `flake.nix` enables simple installation via `nix profile install github:yunusemreyl/omen-space`.
+- **OpenSUSE:** Uses `zypper` to install dependencies and kernel development packages.
 
 ---
 

--- a/setup.sh
+++ b/setup.sh
@@ -23,6 +23,9 @@ install_dependencies() {
     elif command -v pacman &> /dev/null; then
         echo "Detected Arch Linux. Installing dependencies via pacman..."
         pacman -S --needed --noconfirm rust cargo gcc pkgconf gtk4 libadwaita systemd dbus base-devel linux-headers dkms
+    elif command -v zypper &> /dev/null; then
+        echo "Detected openSUSE. Installing dependencies via zypper..."
+        zypper install -y rust cargo gcc make pkgconfig gtk4-devel libadwaita-devel systemd-devel dbus-1-devel kernel-devel dkms
     else
         echo "Warning: Unsupported package manager. Please ensure rust, cargo, gtk4, and libadwaita dev packages are installed."
     fi


### PR DESCRIPTION
## Summary
Adds openSUSE system support to `setup.sh` by detecting `zypper` and mapping the required build dependencies to openSUSE package names.

## Key Changes
* Added a `zypper` branch to `install_dependencies()` in `setup.sh`.
* Mapped standard build dependencies to their openSUSE equivalents (`dbus-1-devel`, `gtk4-devel`, `libadwaita-devel`, `kernel-devel`, `pkgconfig`, `dkms`, `rust`, `cargo`, `gcc`, `make`).

## How to Test
1. On openSUSE, run `sudo ./setup.sh install`.
2. Verify `zypper` successfully resolves and installs all required dependencies without missing package errors.