### PR TITLE
fix(tray,gui): ensure tray presence and single-instance lifecycle

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -232,6 +232,15 @@ EOF
         echo -e "\n❌ ERROR: CLI failed to communicate with the daemon. Check 'systemctl status omen-space-daemon'."
     fi
 
+    if [ -n "$SUDO_USER" ] && [ -x /usr/bin/omen-tray ]; then
+        local user_id
+        user_id=$(id -u "$SUDO_USER")
+        if [ -d "/run/user/$user_id" ]; then
+            echo "Starting omen-tray for $SUDO_USER..."
+            su - "$SUDO_USER" -c "DISPLAY=${DISPLAY:-:0} WAYLAND_DISPLAY=${WAYLAND_DISPLAY:-wayland-0} XDG_RUNTIME_DIR=/run/user/$user_id /usr/bin/omen-tray >/dev/null 2>&1 &" || true
+        fi
+    fi
+
     echo "====================================="
     echo " Cleaning build cache to free disk space..."
     echo "====================================="

--- a/src/omen-gui/src/main.rs
+++ b/src/omen-gui/src/main.rs
@@ -19,9 +19,52 @@ mod asset_resolver;
 
 const APP_ID: &str = "org.hp.OmenSpace";
 
+fn ensure_tray_running() {
+    let is_running = std::process::Command::new("pgrep")
+        .arg("-x")
+        .arg("omen-tray")
+        .output()
+        .map(|o| o.status.success() && !o.stdout.is_empty())
+        .unwrap_or(false);
+
+    if !is_running {
+        let spawned = std::env::current_exe()
+            .ok()
+            .and_then(|p| p.parent().map(|dir| dir.join("omen-tray")))
+            .and_then(|tray_path| {
+                if tray_path.exists() {
+                    std::process::Command::new(tray_path)
+                        .stdin(std::process::Stdio::null())
+                        .stdout(std::process::Stdio::null())
+                        .stderr(std::process::Stdio::null())
+                        .spawn()
+                        .ok()
+                } else {
+                    None
+                }
+            });
+
+        if spawned.is_none() {
+            let _ = std::process::Command::new("omen-tray")
+                .stdin(std::process::Stdio::null())
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::null())
+                .spawn()
+                .or_else(|_| {
+                    std::process::Command::new("/usr/bin/omen-tray")
+                        .stdin(std::process::Stdio::null())
+                        .stdout(std::process::Stdio::null())
+                        .stderr(std::process::Stdio::null())
+                        .spawn()
+                });
+        }
+    }
+}
+
 fn main() {
     let app = adw::Application::builder().application_id(APP_ID).build();
     app.connect_startup(|_| {
+        ensure_tray_running();
         adw::init().expect("Failed to initialize libadwaita");
         i18n::init();
         
@@ -91,8 +134,10 @@ fn apply_appearance_mode() {
 fn build_ui(app: &adw::Application) {
     apply_startup_profile();
     apply_appearance_mode();
+    ensure_tray_running();
 
-    if let Some(window) = app.active_window() {
+    if let Some(window) = app.active_window().or_else(|| app.windows().first().cloned()) {
+        window.set_visible(true);
         window.present();
         return;
     }
@@ -106,6 +151,7 @@ fn build_ui(app: &adw::Application) {
 
     // Close button hides the window instead of killing the process (Minimize to Tray)
     window.connect_close_request(move |win| {
+        ensure_tray_running();
         win.set_visible(false);
         gtk::glib::Propagation::Stop
     });

--- a/src/omen-tray/Cargo.lock
+++ b/src/omen-tray/Cargo.lock
@@ -772,6 +772,7 @@ dependencies = [
  "env_logger",
  "glib",
  "ksni",
+ "libc",
  "log",
  "serde",
  "serde_json",

--- a/src/omen-tray/Cargo.toml
+++ b/src/omen-tray/Cargo.toml
@@ -12,6 +12,7 @@ env_logger = "0.10"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 glib = "0.18"
+libc = "0.2"
 
 [profile.release]
 opt-level = "z"

--- a/src/omen-tray/src/main.rs
+++ b/src/omen-tray/src/main.rs
@@ -18,6 +18,62 @@ where
     }
 }
 
+fn acquire_single_instance_lock() -> Option<std::fs::File> {
+    let runtime_dir = std::env::var("XDG_RUNTIME_DIR")
+        .unwrap_or_else(|_| format!("/tmp/user-{}", unsafe { libc::getuid() }));
+    let lock_path = format!("{}/omen-tray.lock", runtime_dir);
+
+    let file = std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(&lock_path)
+        .ok()?;
+
+    use std::os::unix::io::AsRawFd;
+    let fd = file.as_raw_fd();
+    let res = unsafe { libc::flock(fd, libc::LOCK_EX | libc::LOCK_NB) };
+    if res != 0 {
+        return None;
+    }
+
+    Some(file)
+}
+
+fn spawn_gui() {
+    let spawned = std::env::current_exe()
+        .ok()
+        .and_then(|p| p.parent().map(|dir| dir.join("omen-gui")))
+        .and_then(|gui_path| {
+            if gui_path.exists() {
+                Command::new(gui_path)
+                    .stdin(std::process::Stdio::null())
+                    .stdout(std::process::Stdio::null())
+                    .stderr(std::process::Stdio::null())
+                    .spawn()
+                    .ok()
+            } else {
+                None
+            }
+        });
+
+    if spawned.is_none() {
+        let _ = Command::new("omen-gui")
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .or_else(|_| {
+                Command::new("/usr/bin/omen-gui")
+                    .stdin(std::process::Stdio::null())
+                    .stdout(std::process::Stdio::null())
+                    .stderr(std::process::Stdio::null())
+                    .spawn()
+            });
+    }
+}
+
 #[derive(Debug, Clone)]
 struct Tray {
     power_profile: String,
@@ -70,7 +126,7 @@ impl ksni::Tray for Tray {
     }
 
     fn activate(&mut self, _x: i32, _y: i32) {
-        let _ = Command::new("omen-gui").spawn();
+        spawn_gui();
     }
 
     fn menu(&self) -> Vec<ksni::MenuItem<Self>> {
@@ -82,7 +138,7 @@ impl ksni::Tray for Tray {
                 label: "OMENSpace'i Aç".into(),
                 icon_name: "omenspace".into(),
                 activate: Box::new(|_| {
-                    let _ = Command::new("omen-gui").spawn();
+                    spawn_gui();
                 }),
                 ..Default::default()
             }
@@ -179,6 +235,8 @@ impl ksni::Tray for Tray {
                 label: "❌ Çıkış".into(),
                 icon_name: "application-exit".into(),
                 activate: Box::new(|_| {
+                    let _ = Command::new("pkill").arg("-TERM").arg("-x").arg("omen-gui").output();
+                    let _ = Command::new("pkill").arg("-TERM").arg("-x").arg("omenctl").output();
                     std::process::exit(0);
                 }),
                 ..Default::default()
@@ -262,6 +320,14 @@ async fn set_fan_mode(mode: &str) {
 
 #[tokio::main]
 async fn main() {
+    let _lock_file = match acquire_single_instance_lock() {
+        Some(file) => file,
+        None => {
+            eprintln!("omen-tray zaten çalışıyor, ikinci örnek sonlandırılıyor.");
+            return;
+        }
+    };
+
     env_logger::init();
     info!("omen-tray başlatılıyor...");
 


### PR DESCRIPTION
## Summary

This PR addresses multiple lifecycle and integration issues between `omen-tray` and `omen-gui`:

1. **Single-Instance Protection for `omen-tray`:**
   - Adds a non-blocking `libc::flock` on `$XDG_RUNTIME_DIR/omen-tray.lock`.
   - If another instance is already running (e.g. autostart and GUI spawn racing), the second instance logs a message and exits immediately with code 0.
   - Prevents duplicate tray icons on desktop environments like KDE Plasma and GNOME.

2. **Unified Lifecycle (Tray and GUI as One):**
   - Adds `ensure_tray_running()` to `omen-gui`, checking if `omen-tray` is active before launching it via detached process (`Stdio::null()`).
   - Invoked during GUI startup (`connect_startup`), activation (`build_ui`), and minimization (`connect_close_request`).
   - Ensures that when a user closes the GUI window with "X" (which minimizes/hides the window), the tray icon is guaranteed to be present so the application never becomes an invisible ghost process.

3. **Restore Hidden Window Instead of Duplicate Windows:**
   - In `build_ui`, when `app.active_window()` is `None` because the window was hidden via `win.set_visible(false)`, it falls back to `app.windows().first()`, calls `window.set_visible(true)` and `window.present()`.
   - Reopening OMEN Space from KRunner, terminal, or desktop launcher seamlessly brings back the existing window without allocating duplicate window hierarchies.

4. **Clean Exit from Tray:**
   - The "Quit" menu item in `omen-tray` sends `SIGTERM` to any running `omen-gui` and `omenctl` instances (`pkill -TERM -x omen-gui`) before exiting, ensuring both components terminate cleanly together.

5. **Instant Tray Launch in `setup.sh`:**
   - At the end of `do_install`, launches `omen-tray` for the active desktop user if `$SUDO_USER` is present, making the tray icon immediately visible without requiring a logout/reboot.

## Testing

- Verified on HP Victus Gaming Laptop 16-s0xxx (CachyOS Linux x86_64, KDE Plasma 6.7.4 Wayland).
- Tested launching `omen-gui` without tray: tray icon appears in system tray automatically.
- Tested closing `omen-gui` via "X": window hides, tray remains visible.
- Tested reopening `omen-gui` via KRunner: existing window restores instantly without creating duplicates.
- Tested launching second `omen-tray` process: exits cleanly with code 0.
- Tested "Quit" from tray menu: both tray and GUI terminate cleanly.