### PR TITLE
fix(installer): auto-assign invoking user to omen-hw group

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -204,6 +204,12 @@ EOF
     echo "Creating system users and reloading udev rules..."
     systemd-sysusers || true
     udevadm control --reload-rules && udevadm trigger || true
+    
+    # Automatically add the invoking sudo user to the omen-hw group
+    if [[ -n "$SUDO_USER" && "$SUDO_USER" != "root" ]]; then
+        echo "Adding user '$SUDO_USER' to omen-hw group..."
+        usermod -aG omen-hw "$SUDO_USER" || true
+    fi
 
     echo "====================================="
     echo " Installing DKMS Kernel Driver"


### PR DESCRIPTION
## Summary
Fixes `ServiceUnknown` D-Bus communication errors after installation by automatically adding the regular user who invoked `sudo ./setup.sh` to the `omen-hw` group.

## Key Changes
* Updated `do_install()` in `setup.sh` to check for `$SUDO_USER`.
* Automatically executes `usermod -aG omen-hw "$SUDO_USER"` during installation so the user gets D-Bus access permissions automatically.

## How to Test
1. Run `sudo ./setup.sh install` as a non-root user via `sudo`.
2. Confirm the installer prints `Adding <username> to omen-hw group...`.
3. Open a new terminal session and verify `omen-cli system info` communicates with the daemon without requiring `sudo`.