### PR TITLE
fix(daemon): resolve daemon hangs and GUI freezes during GPU power-state transitions (#198)

### DIFF
--- a/src/omen-gui/src/daemon_client.rs
+++ b/src/omen-gui/src/daemon_client.rs
@@ -346,27 +346,34 @@ where
     if !TELEMETRY_STARTED.swap(true, std::sync::atomic::Ordering::SeqCst) {
         let rt = get_runtime();
         rt.spawn(async move {
-            if let Ok(conn) = get_conn().await {
-                if let Ok(proxy) = SysMonProxy::new(&conn).await {
-                    if let Ok(mut stream) = proxy.receive_telemetry_updated().await {
-                        use zbus::export::futures_util::StreamExt;
-                        while let Some(signal) = stream.next().await {
-                            if let Ok(args) = signal.args() {
-                                let json_str = args.json_stats();
-                                if let Ok(stats) = serde_json::from_str::<SystemStats>(json_str) {
-                                    if let Some(mutex) = TELEMETRY_SENDERS.get() {
-                                        let senders = mutex.lock().unwrap_or_else(|e| e.into_inner());
-                                        for tx in senders.iter() {
-                                            let _ = tx.send(stats.clone());
+            use zbus::export::futures_util::StreamExt;
+            loop {
+                if let Ok(conn) = get_conn().await {
+                    if let Ok(proxy) = SysMonProxy::new(&conn).await {
+                        if let Ok(mut stream) = proxy.receive_telemetry_updated().await {
+                            while let Some(signal) = stream.next().await {
+                                if let Ok(args) = signal.args() {
+                                    let json_str = args.json_stats();
+                                    if let Ok(stats) = serde_json::from_str::<SystemStats>(json_str) {
+                                        if let Some(mutex) = TELEMETRY_SENDERS.get() {
+                                            let senders = mutex.lock().unwrap_or_else(|e| e.into_inner());
+                                            for tx in senders.iter() {
+                                                let _ = tx.send(stats.clone());
+                                            }
                                         }
+                                    } else {
+                                        eprintln!("Telemetry parse error. JSON: {}", json_str);
                                     }
-                                } else {
-                                    eprintln!("Telemetry parse error. JSON: {}", json_str);
                                 }
                             }
                         }
                     }
                 }
+                // If we reach this point, the stream has ended (daemon crashed, 
+                // daemon restarted, or DBus dropped). 
+                // We sleep for 3 seconds as a backoff before retrying to prevent 
+                // a tight CPU spin-loop while the daemon is offline.
+                tokio::time::sleep(std::time::Duration::from_secs(3)).await;
             }
         });
     }

--- a/src/omen-space-daemon/src/sysmon.rs
+++ b/src/omen-space-daemon/src/sysmon.rs
@@ -387,32 +387,45 @@ struct GpuMetrics {
     power: Option<f64>,
 }
 
+static NVML_INSTANCE: OnceLock<Mutex<Option<nvml_wrapper::Nvml>>> = OnceLock::new();
+
 fn fetch_gpu_metrics_with_timeout() -> Option<GpuMetrics> {
     let (tx, rx) = std::sync::mpsc::channel();
+    
     std::thread::spawn(move || {
-        if let Ok(nvml) = nvml_wrapper::Nvml::init() {
-            if let Ok(device) = nvml.device_by_index(0) {
-                let gfx = device.running_graphics_processes().map(|v| v.len()).unwrap_or(0);
-                let comp = device.running_compute_processes().map(|v| v.len()).unwrap_or(0);
-                let has_clients = (gfx + comp) > 0;
-                
-                let mut temp = None;
-                let mut power = None;
-                
-                if has_clients {
-                    if let Ok(t) = device.temperature(nvml_wrapper::enum_wrappers::device::TemperatureSensor::Gpu) {
-                        temp = Some(t as i32);
+        // Get or initialize the cached NVML instance
+        let nvml_lock = NVML_INSTANCE.get_or_init(|| {
+            Mutex::new(nvml_wrapper::Nvml::init().ok())
+        });
+
+        // Use try_lock() to avoid piling up threads if one is blocked in D3cold/D0 transition
+        if let Ok(mut nvml_guard) = nvml_lock.try_lock() {
+            if let Some(nvml) = nvml_guard.as_mut() {
+                if let Ok(device) = nvml.device_by_index(0) {
+                    let gfx = device.running_graphics_processes().map(|v| v.len()).unwrap_or(0);
+                    let comp = device.running_compute_processes().map(|v| v.len()).unwrap_or(0);
+                    let has_clients = (gfx + comp) > 0;
+                    
+                    let mut temp = None;
+                    let mut power = None;
+                    
+                    if has_clients {
+                        if let Ok(t) = device.temperature(nvml_wrapper::enum_wrappers::device::TemperatureSensor::Gpu) {
+                            temp = Some(t as i32);
+                        }
+                        if let Ok(p) = device.power_usage() {
+                            power = Some(p as f64 / 1000.0);
+                        }
                     }
-                    if let Ok(p) = device.power_usage() {
-                        power = Some(p as f64 / 1000.0);
-                    }
+                    let _ = tx.send(GpuMetrics { has_clients, temp, power });
                 }
-                let _ = tx.send(GpuMetrics { has_clients, temp, power });
             }
         }
     });
+
     rx.recv_timeout(std::time::Duration::from_millis(500)).ok()
 }
+
 pub fn get_safe_gpu_temp() -> f64 {
     let nvidia_state = check_nvidia_state();
     let is_nvidia_awake = nvidia_state.unwrap_or(false);
@@ -594,6 +607,7 @@ pub fn fetch_system_stats() -> SystemStats {
     let nvidia_state = check_nvidia_state();
     let is_nvidia_awake = nvidia_state.unwrap_or(false);
     let has_nvidia = nvidia_state.is_some();
+    let mut nvml_timed_out = false;
 
     // 1. Check if we are in an intentional quiet window to let the driver sleep
     let in_cooldown = {
@@ -630,7 +644,10 @@ pub fn fetch_system_stats() -> SystemStats {
                 }
             }
         }
-
+        else {
+            // NVML timed out! The NVIDIA driver is busy/hanging.
+            nvml_timed_out = true; 
+        }
         if !has_active_clients {
             // Zero game/render clients detected. Arm 6s quiet window so kernel can suspend.
             let mut guard = GPU_IDLE_COOLDOWN.lock().unwrap_or_else(|e| e.into_inner());
@@ -641,7 +658,7 @@ pub fn fetch_system_stats() -> SystemStats {
     }
 
     // Fallback to sysfs hwmon GPU paths if NVML did not yield metrics (e.g. open source drivers like nouveau/amdgpu)
-    if stats.gpu_temp == 0 {
+    if stats.gpu_temp == 0 && !has_nvidia && !nvml_timed_out {
         if let Some(ref p) = paths.gpu_temp_path {
             if let Ok(s) = fs::read_to_string(p) {
                 if let Ok(milli) = s.trim().parse::<f64>() {
@@ -650,7 +667,7 @@ pub fn fetch_system_stats() -> SystemStats {
             }
         }
     }
-    if stats.gpu_pwr <= 0.0 {
+    if stats.gpu_pwr <= 0.0 && !has_nvidia && !nvml_timed_out {
         if let Some(ref p) = paths.gpu_pwr_path {
             if let Ok(s) = fs::read_to_string(p) {
                 if let Ok(micro) = s.trim().parse::<f64>() {


### PR DESCRIPTION
### Summary
Resolves an intermittent daemon deadlock and GUI freeze occurring during dGPU power-state churn (e.g., fullscreen gaming and alt-tabbing on hybrid/NVIDIA systems, or during AC/battery state transitions as reported in #198).

### Root Cause
1. **Unbounded Leaked NVML Queries**: Previously, NVML re-initialized on an unjoined, fire-and-forget OS thread every polling cycle. If NVML or driver calls blocked during D3cold/D0 transitions, the 500ms timeout abandoned the thread inside the driver. These leaked threads eventually caused internal driver lock contention.
2. **Synchronous Sysfs D-State Deadlock**: When NVML timed out or reported zero active clients during idle drop, the daemon fell back to synchronous sysfs hwmon reads (`/sys/class/hwmon/.../temp1_input`). Issuing synchronous reads against an NVIDIA hwmon sysfs node during power-state transitions causes an uninterruptible kernel sleep (D-state) lock on the daemon's main thread, stopping the D-Bus signal stream.
3. **One-Shot Telemetry Listener in GUI**: In `daemon_client.rs`, the telemetry stream subscription was guarded by a one-way atomic flag with no reconnect loop. If the D-Bus connection or daemon hiccuped, the task died permanently and stats froze until daemon restart.

### Changes
* **Daemon (`sysmon.rs`)**:
  * Cached a single `nvml_wrapper::Nvml` instance inside a static `OnceLock<Mutex<Option<Nvml>>>` and utilized `try_lock()` to prevent lock contention and unbounded thread spawning.
  * Added a `nvml_timed_out` flag to detect hanging NVML queries.
  * Prevented synchronous sysfs hwmon fallback reads if an NVIDIA card is present or if NVML timed out (`!has_nvidia && !nvml_timed_out`), eliminating kernel D-state locks.
* **Client (`daemon_client.rs`)**:
  * Wrapped `proxy.receive_telemetry_updated()` inside a continuous reconnect loop with a 3-second sleep backoff so the GUI automatically resumes listening when the daemon or D-Bus recovers.

### Testing
- Tested running fullscreen workloads on AC power.
- Verified repeatedly alt-tabbing to and from the game does not wedge the daemon or leak driver worker threads.
- Confirmed the GUI telemetry widgets smoothly resume streaming stats without requiring a manual daemon restart.